### PR TITLE
Fix false-positive remote Yjs content detection during editor sync

### DIFF
--- a/frontend/open-scribe/src/hooks/useCollaboration.js
+++ b/frontend/open-scribe/src/hooks/useCollaboration.js
@@ -80,17 +80,14 @@ export function useCollaboration(documentId, { enabled = true } = {}) {
 
       const xmlFrag = session.ydoc.getXmlFragment("default");
       const html = initialContentRef.current;
+      const hasRemoteContent = yDocHasMeaningfulContent(xmlFrag);
 
-      console.log("[collab] finishSync — xmlFrag.length:", xmlFrag.length, "| html:", html?.substring(0, 60));
-
-      if (xmlFrag.length === 0 && html && html.trim() && html !== "<p></p>") {
+      if (!hasRemoteContent && html && html.trim() && html !== "<p></p>") {
         // Y.Doc is empty AND we have DB content → need to seed
         session.pendingHtml = html;
-        console.log("[collab] pendingHtml set for seeding:", html.substring(0, 40));
       } else {
         // Y.Doc already has content from server — DO NOT seed
         session.pendingHtml = undefined;
-        console.log("[collab] Y.Doc has server content, no seeding needed");
       }
 
       cbRef.current.setSynced(true);
@@ -148,4 +145,19 @@ function randomColor(seed) {
     hash = seed.charCodeAt(i) + ((hash << 5) - hash);
   }
   return `hsl(${Math.abs(hash) % 360}, 70%, 60%)`;
+}
+
+function yDocHasMeaningfulContent(xmlFrag) {
+  if (!xmlFrag || xmlFrag.length === 0) return false;
+  if (xmlFrag.length > 1) return true;
+
+  const textContent = xmlFrag
+    .toString()
+    .replace(/<[^>]+>/g, "")
+    .replace(/\u200b/g, "")
+    .trim();
+  if (textContent.length > 0) return true;
+
+  const firstNode = xmlFrag.get(0);
+  return firstNode?.nodeName !== "paragraph";
 }


### PR DESCRIPTION
### Motivation
- Prevent DB HTML fallback from being skipped when a newly-initialized Y.Doc contains only the default empty paragraph node which made `xmlFrag.length` appear non-zero.
- Ensure editors are seeded with persisted HTML when the remote document is effectively empty so users don't see blank documents after sync.

### Description
- Replaced the `xmlFrag.length === 0` check with a semantic check using a new helper `yDocHasMeaningfulContent(xmlFrag)` in `frontend/open-scribe/src/hooks/useCollaboration.js`.
- Implemented `yDocHasMeaningfulContent` to treat truly empty fragments and a single default paragraph as empty, treat multi-node docs or non-empty text as meaningful, and handle zero/one-node edge cases.
- Updated the `finishSync` flow to use the new helper to decide whether to set `session.pendingHtml` for DB seeding.
- Removed temporary debug logging from the sync path to keep output cleaner.

### Testing
- Ran `npm run build` in `frontend/open-scribe` and the production build completed successfully.
- Ran `npm run lint` in `frontend/open-scribe` which failed due to many pre-existing lint violations across the frontend unrelated to this change, so lint did not pass in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17e4c45ec8320944424c0f3284f9f)